### PR TITLE
Feature/review20210528

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { BiChevronDown, BiChevronUp } from "react-icons/bi";
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import Navbar from "./Navbar";
 import { Link } from "react-router-dom";
 import UserContext from "../contexts/UserContext";

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -20,7 +20,7 @@ export default function Header(){
                     <img src={user.user.avatar} alt={user.user.username}/>
                 </div>
             </Title>
-            {showMenu && <Navbar />}
+            {showMenu && <Navbar setShowMenu={setShowMenu}/>}
         </>
     );
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -5,8 +5,7 @@ import Navbar from "./Navbar";
 import { Link } from "react-router-dom";
 import UserContext from "../contexts/UserContext";
 
-export default function Header(){
-    const [showMenu, setShowMenu] = useState(false);
+export default function Header({showMenu, setShowMenu}){
     const { user } = useContext(UserContext);
 
     return(
@@ -16,11 +15,26 @@ export default function Header(){
                     <h1>linkr</h1>
                 </Link>
                 <div>
-                    {showMenu ? <BiChevronUp onClick={() => setShowMenu(!showMenu)} color="#FFF" size="50px" cursor="pointer" /> : <BiChevronDown onClick={() => setShowMenu(!showMenu)} color="#FFF" size="50px" cursor="pointer" />}               
-                    <img src={user.user.avatar} alt={user.user.username}/>
+                    {showMenu 
+                        ? <BiChevronUp 
+                            onClick={(e) => setShowMenu(!showMenu)} 
+                            color="#FFF" 
+                            size="50px" 
+                            cursor="pointer" 
+                        /> : <BiChevronDown 
+                            onClick={(e) => setShowMenu(!showMenu)} 
+                            color="#FFF" 
+                            size="50px" 
+                            cursor="pointer" 
+                        />}               
+                    <img 
+                        onClick={(e) => setShowMenu(!showMenu)}
+                        src={user.user.avatar} 
+                        alt={user.user.username}
+                    />
                 </div>
             </Title>
-            {showMenu && <Navbar setShowMenu={setShowMenu}/>}
+            {<Navbar showMenu={showMenu} setShowMenu={setShowMenu}/>}
         </>
     );
 }
@@ -56,5 +70,6 @@ const Title = styled.div`
         object-fit: cover;
         border-radius: 50%;
         user-select: none;
+        cursor: pointer;
     }
 `;

--- a/src/components/LayoutInterface/LayoutInterface.js
+++ b/src/components/LayoutInterface/LayoutInterface.js
@@ -1,25 +1,14 @@
 import Header from "../Header";
 import Trending from "../Trending";
 import styled from "styled-components"
-
-// LayoutInterface eh um componente opinionado que espera 1 child dentro 
-// dele e um nome de pagina passado como prop pageTitle
-// o componente renderiza o layout padronizado da pagina e inclui a child na coluna principal
-
-// como usar LayoutInterface :
-// <LayoutInterface pageTitle="nome da pagina">
-//   <componente que vai dentro de Box (pode incluir a caixa de adicionar novo post) />
-// </LayoutInterface>
-// exemplo:
-// <LayoutInterface pageTitle="timeline">
-//   <PostCreatorBox />
-//   <Posts posts={posts} />
-// </LayoutInterface>
+import {useState} from 'react';
 
 export default function LayoutInterface({pageTitle, children}){
+    const [showMenu, setShowMenu] = useState(false);
+
     return(
-        <Main>
-            <Header />
+        <Main onClick={()=>{if(showMenu) setShowMenu(false)}}>
+            <Header showMenu={showMenu} setShowMenu={setShowMenu}/>
             <Title>{pageTitle}</Title>
             <Content>
               <Box>

--- a/src/components/MyLikes.js
+++ b/src/components/MyLikes.js
@@ -17,7 +17,8 @@ export default function MyLikes () {
         const request = axios.get("https://mock-api.bootcamp.respondeai.com.br/api/v2/linkr/posts/liked", config)
         request.then(response => {
             setRenderPage(true)
-            setPosts(response.data.posts)
+            const posts = response.data.posts;
+            setPosts(posts.reverse());
             })
         request.catch((err) => alert(`Falha ao buscar posts erro ${err.response.status}`));
     },

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,19 +1,16 @@
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { useHistory } from "react-router-dom";
-import { useEffect, useRef } from 'react';
 
-export default function Navbar({setShowMenu}){
+export default function Navbar({showMenu}){
     const history = useHistory();
     function logOut(){
         localStorage.clear();
         history.push("/");
     }
 
-    const ref = useRef(null);
-    useClickOutside(ref, setShowMenu);
     return(
-        <Box ref={ref}>
+        <Box showMenu={showMenu} >
             <Link to="/my-posts">
                 <div><h1>My posts</h1></div>
             </Link>
@@ -25,19 +22,6 @@ export default function Navbar({setShowMenu}){
             </em>
         </Box>
     );
-}
-
-function useClickOutside(ref, setShowMenu){
-    useEffect(()=>{
-        const handleClickOutside = (e) => {
-            if (ref.current && !ref.current.contains(e.target)){
-                e.preventDefault();
-                setShowMenu(false);
-            }
-        }
-        document.addEventListener('click', handleClickOutside);
-        return () => document.removeEventListener('click', handleClickOutside);
-    },[ref]) // eslint-disable-line react-hooks/exhaustive-deps
 }
 
 const Box = styled.nav`
@@ -52,14 +36,13 @@ const Box = styled.nav`
     color: #FFF;
     font-size: 17px;
     border-bottom-left-radius: 20px;
-    animation-name: menu;
-    animation-duration: 1s;
-    z-index: 1;
 
-    @keyframes menu {
-        0%   {right:0px; top:0px;}
-        100% {right:0px; top:72px;}
-    }
+    z-index: 1;
+    top: ${({showMenu})=>showMenu?"72px":"-58px"};
+
+    transition: top 150ms ease-in-out;
+
+    overflow: hidden;
 
     div{
         width: 100%;
@@ -67,7 +50,6 @@ const Box = styled.nav`
         display: flex;
         justify-content: center;
         align-items: center;
-        transition: all .2s linear;
         cursor: pointer;
         margin-top: 11px;
         padding-top: 5px;
@@ -79,7 +61,7 @@ const Box = styled.nav`
             font-size: 17px;
         }
 
-        :nth-child(3n){
+        :nth-child(3){
             border-bottom-left-radius: 20px;
         }
 

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -31,11 +31,12 @@ function useClickOutside(ref, setShowMenu){
     useEffect(()=>{
         const handleClickOutside = (e) => {
             if (ref.current && !ref.current.contains(e.target)){
+                e.preventDefault();
                 setShowMenu(false);
             }
         }
-        document.addEventListener('mousedown', handleClickOutside);
-        return () => document.removeEventListener('mousedown', handleClickOutside);
+        document.addEventListener('click', handleClickOutside);
+        return () => document.removeEventListener('click', handleClickOutside);
     },[ref]) // eslint-disable-line react-hooks/exhaustive-deps
 }
 

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,16 +1,19 @@
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { useHistory } from "react-router-dom";
+import { useEffect, useRef } from 'react';
 
-export default function Navbar(){
+export default function Navbar({setShowMenu}){
     const history = useHistory();
     function logOut(){
         localStorage.clear();
         history.push("/");
     }
 
+    const ref = useRef(null);
+    useClickOutside(ref, setShowMenu);
     return(
-        <Box>
+        <Box ref={ref}>
             <Link to="/my-posts">
                 <div><h1>My posts</h1></div>
             </Link>
@@ -22,6 +25,18 @@ export default function Navbar(){
             </em>
         </Box>
     );
+}
+
+function useClickOutside(ref, setShowMenu){
+    useEffect(()=>{
+        const handleClickOutside = (e) => {
+            if (ref.current && !ref.current.contains(e.target)){
+                setShowMenu(false);
+            }
+        }
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    },[ref]) // eslint-disable-line react-hooks/exhaustive-deps
 }
 
 const Box = styled.nav`

--- a/src/components/Posts/Post/Caption.js
+++ b/src/components/Posts/Post/Caption.js
@@ -8,6 +8,7 @@ import TextareaAutosize from "react-textarea-autosize";
 export default function Caption(props) {
     const {
         caption,
+        setCaption,
         onEdition,
         toggleEdition,
         editedText,
@@ -55,6 +56,7 @@ export default function Caption(props) {
         request.then((response) => {
             setDisabled(false);
             setEditableCaption(editedText);
+            setCaption(editedText);
             toggleEdition();
         });
 

--- a/src/components/Posts/Post/Post.js
+++ b/src/components/Posts/Post/Post.js
@@ -21,8 +21,9 @@ ReactModal.defaultStyles.overlay.zIndex = 5;
 Modal.setAppElement(document.querySelector(".root"));
 
 export default function Post(props) {
-    const { postID, originalPoster, caption, likes, linkProps } =
+    const { postID, originalPoster, likes, linkProps } =
         props;
+    const [caption, setCaption] = useState(props.caption);
     const {post, posts, setPosts} = props;
     const { user } = useContext(UserContext);
     const [modalIsOpen, setModalIsOPen] = useState(false);
@@ -117,6 +118,7 @@ export default function Post(props) {
                     </header>
                     <Caption
                         caption={caption}
+                        setCaption={setCaption}
                         onEdition={onEdition}
                         toggleEdition={toggleEdition}
                         editedText={editedText}


### PR DESCRIPTION
Disliking a post at /my-likes will now remove the post from the page
The order of the posts at /my-likes has been reversed so the last like will show up on top
Toggle off the navbar menu when the user clicks outside of it

These were the requested changes during the Sprint Review that took place on the 28th of May, 2021